### PR TITLE
[sentry] Fix config parameter for sentry >= 8.x

### DIFF
--- a/sentry/sentry-celery.service
+++ b/sentry/sentry-celery.service
@@ -6,7 +6,7 @@ After=network.target
 User=sentry
 Restart=always
 Environment=PATH=/opt/sentry/bin
-ExecStart=/opt/sentry/bin/sentry --config=/etc/sentry/sentry.conf.py celery worker --loglevel=ERROR -B -s /opt/sentry/celery/celerybeat-schedule
+ExecStart=/opt/sentry/bin/sentry --config=/etc/sentry celery worker --loglevel=ERROR -B -s /opt/sentry/celery/celerybeat-schedule
 
 [Install]
 WantedBy=multi-user.target

--- a/sentry/sentry.install
+++ b/sentry/sentry.install
@@ -11,11 +11,12 @@ post_install(){
     /usr/bin/chown sentry:sentry /opt/sentry/celery
 
     # Generate a new configuration.
-    if [ ! -e "/etc/sentry/sentry.conf.py" ] ; then
-        "/opt/sentry/bin/sentry" init "/etc/sentry/sentry.conf.py"
+    if [ ! -e "/etc/sentry/sentry.conf.py" ] || [ ! -e "/etc/sentry/config.yml" ] ; then
+        "/opt/sentry/bin/sentry" init "/etc/sentry"
     fi
 
     /usr/bin/chmod 0600 /etc/sentry/sentry.conf.py
+    /usr/bin/chmod 0600 /etc/sentry/config.yml
 
 cat << EOF
 
@@ -42,12 +43,12 @@ step.
 3) Run migrations:
 
     sudo -u sentry PATH=/opt/sentry/bin:\$PATH \\
-        /opt/sentry/bin/sentry --config=/etc/sentry/sentry.conf.py upgrade
+        /opt/sentry/bin/sentry --config=/etc/sentry upgrade
 
 4) Create the initial superuser:
 
     sudo -u sentry PATH=/opt/sentry/bin:\$PATH \\
-        /opt/sentry/bin/sentry --config=/etc/sentry/sentry.conf.py createuser
+        /opt/sentry/bin/sentry --config=/etc/sentry createuser
 
 5) Start Sentry:
 
@@ -56,7 +57,7 @@ step.
 If you wish to run Sentry manually, e.g. to test your configuration:
 
     sudo -u sentry PATH=/opt/sentry/bin:\$PATH \\
-        --config=/etc/sentry/sentry.conf.py start
+        /opt/sentry/bin/sentry --config=/etc/sentry start
 
 EXTRAS
 
@@ -94,6 +95,7 @@ post_upgrade(){
     /usr/bin/chown sentry:sentry /opt/sentry/celery
 
     /usr/bin/chmod 0600 /etc/sentry/sentry.conf.py
+    /usr/bin/chmod 0600 /etc/sentry/config.yml
 
 cat << EOF
 
@@ -135,7 +137,7 @@ this step if you do):
 !!! ALWAYS BACK-UP YOUR DATABASE PRIOR TO UPGRADING SENTRY !!!
 
     sudo -u sentry PATH=/opt/sentry/bin:\$PATH \\
-        /opt/sentry/bin/sentry --config=/etc/sentry/sentry.conf.py upgrade
+        /opt/sentry/bin/sentry --config=/etc/sentry upgrade
 
 5) Start Sentry:
 
@@ -144,7 +146,7 @@ this step if you do):
 If you wish to run Sentry manually, e.g. to test your configuration:
 
     sudo -u sentry PATH=/opt/sentry/bin:\$PATH \\
-        --config=/etc/sentry/sentry.conf.py start
+        /opt/sentry/bin/sentry --config=/etc/sentry start
 
 EXTRAS
 

--- a/sentry/sentry.service
+++ b/sentry/sentry.service
@@ -7,7 +7,7 @@ Requires=sentry-celery.service
 User=sentry
 Restart=always
 Environment=PATH=/opt/sentry/bin
-ExecStart=/opt/sentry/bin/sentry --config=/etc/sentry/sentry.conf.py start
+ExecStart=/opt/sentry/bin/sentry --config=/etc/sentry start
 KillSignal=SIGINT
 
 [Install]


### PR DESCRIPTION
In sentry 8.x you get the config,yml file for changing a few minimal settings for now, but this file will be ignored unless you adjust the config parameter (or add an environment variable SENTRY_CONFIG) to point at the config directory instead of the specific "old" config file.

I found that because sentry was ignoring my email config when still pointed at the sentry.config.py file (or it showed deprecation notices when I configured it in the sentry.conf.py)
