### PR TITLE
Ensures config files are generated by non-root

### DIFF
--- a/sentry/sentry.install
+++ b/sentry/sentry.install
@@ -9,7 +9,7 @@ post_install(){
 
     # Generate a new configuration.
     if [ ! -e "/etc/sentry/sentry.conf.py" ] || [ ! -e "/etc/sentry/config.yml" ] ; then
-        "/opt/sentry/bin/sentry" init "/etc/sentry"
+        sudo -u sentry "/opt/sentry/bin/sentry" init "/etc/sentry"
     fi
 
     /usr/bin/chmod 0600 /etc/sentry/sentry.conf.py
@@ -19,12 +19,7 @@ cat << EOF
 
 INSTALLATION STEPS
 
-1) Initialize Sentry's configuration:
-
-    sudo -u sentry /opt/sentry/bin/sentry init /etc/sentry
-
-Be sure to edit the configurations in /etc/sentry before proceeding to the next
-step.
+1) Edit the configurations in /etc/sentry before proceeding to the next step.
 
 2) Run migrations:
 


### PR DESCRIPTION
Currently, the `/etc/sentry` folder is created and set to be owned by the `sentry` user, but then _the config files are generated by root_. This has the effect of the folder being owned by `sentry`, but the files within not being readable or editable