### PR TITLE
Adds [install] section to sentry.service

### DIFF
--- a/sentry/sentry.service
+++ b/sentry/sentry.service
@@ -6,3 +6,7 @@ Requires=sentry-web.service sentry-celery.service sentry-cron.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/true
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
The instructions say that I can just [`sudo systemd enable sentry`](https://github.com/zancarius/archlinux-pkgbuilds/blob/master/sentry/sentry.install#L186), but there's no `[install]` section. However, there are `install` sections for each of the "subservices", like sentry -web, -cron, and -celery?

This PR allows `systemd enable sentry` to work again. I wasn't sure if it should be added to the `.service` or the `.target`, but considering how the `.target` doesn't have its "wants" set (and I _think_ that you need those?), I opted for the `.service`